### PR TITLE
add environment variable support.

### DIFF
--- a/build_plan_parser.go
+++ b/build_plan_parser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2"
 
@@ -23,14 +24,14 @@ func (p BuildPlanParser) Parse(path string) ([]packit.BuildPlanRequirement, []pa
 			return nil, nil, nil
 		}
 
-		return nil, nil, fmt.Errorf("failed to read plan.toml: %w", err)
+		return nil, nil, fmt.Errorf("failed to read %s: %w", filepath.Base(path), err)
 	}
 	defer file.Close()
 
 	var plan packit.BuildPlan
 	err = toml.NewDecoder(file).Decode(&plan)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to decode plan.toml: %w", err)
+		return nil, nil, fmt.Errorf("failed to decode %s: %w", filepath.Base(path), err)
 	}
 
 	var orRequirements []packit.BuildPlanRequirement

--- a/detect.go
+++ b/detect.go
@@ -1,6 +1,7 @@
 package buildplan
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -13,7 +14,16 @@ type PlanParser interface {
 
 func Detect(planParser PlanParser) packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-		requirements, orRequirements, err := planParser.Parse(filepath.Join(context.WorkingDir, "plan.toml"))
+		planfile, ok := os.LookupEnv("BP_PLAN_FILE")
+		if !ok {
+			planfile = "plan.toml"
+		}
+
+		if planfile == "" {
+			return packit.DetectResult{}, nil
+		}
+
+		requirements, orRequirements, err := planParser.Parse(filepath.Join(context.WorkingDir, planfile))
 		if err != nil {
 			return packit.DetectResult{}, err
 		}

--- a/detect_test.go
+++ b/detect_test.go
@@ -168,4 +168,58 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+
+	context("a different plan file has been specified", func() {
+		it.Before(func() {
+			planParser.ParseCall.Returns.Requirements = []packit.BuildPlanRequirement{{Name: "dummy"}}
+		})
+		it.After(func() {
+			os.Unsetenv("BP_PLAN_FILE")
+		})
+		context("/custom-plan.toml", func() {
+			it.Before(func() {
+				os.Setenv("BP_PLAN_FILE", "custom-plan.toml")
+			})
+
+			it("passes detection and has those deps in its final buildplan", func() {
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(planParser.ParseCall.Receives.Path).To(Equal(filepath.Join(workingDir, "custom-plan.toml")))
+			})
+		})
+
+		context("/subdir/plan.toml", func() {
+			it.Before(func() {
+				os.Setenv("BP_PLAN_FILE", "subdir/custom-plan.toml")
+			})
+
+			it("passes detection and has those deps in its final buildplan", func() {
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(planParser.ParseCall.Receives.Path).To(Equal(filepath.Join(workingDir, "subdir", "custom-plan.toml")))
+			})
+		})
+
+		context("empty string", func() {
+			it.Before(func() {
+				os.Setenv("BP_PLAN_FILE", "")
+			})
+
+			it("passes detection and has those deps in its final buildplan", func() {
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// When BP_PLAN_FILE is set to an empty string, we skip the plan parsing.
+				Expect(planParser.ParseCall.Receives.Path).To(BeEmpty())
+			})
+		})
+	})
 }


### PR DESCRIPTION
## Summary

Environment variable support for build plans

## Use Cases
In a monorepo that uses the build-plan buildpack, it is sometimes necessary to provide different build plans to different subprojects.  This change makes it possible to configure the name of the build plan file to use using an environment variable.

Setting BP_PLAN_FILE to any value will use that value. Setting BP_PLAN_FILE to an empty string will bypass detection and skip detection.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* I have not linked issue(s).
* I have not added an integration test.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
